### PR TITLE
Piwebcam: Enable overriding of camera settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,43 @@ If you want to modify the image content the quick-and-dirty way (not recommended
 - Start with the `chroot-to-pi` script: https://gist.github.com/htruong/7df502fb60268eeee5bca21ef3e436eb
 - Edit `/bin/bash` to `/bin/sh` on the `chroot /mnt/raspbian /bin/bash` line.
 
+
+Customizing camera settings
+--
+
+Override camera settings temporarily:
+
+Log in to the debug interface. Then list all tweakable parameters:
+
+```bash
+/usr/bin/v4l2-ctl -L | less
+```
+
+Then you can directly apply parameters on the fly:
+
+```
+/usr/bin/v4l2-ctl -c auto_exposure_bias=15
+/usr/bin/v4l2-ctl -c contrast=0
+```
+
+Override camera settings permanently:
+
+Mount the SD card on your computer, and create a file called
+camera.txt in /boot and put all parameters you want overridden, e.g:
+
+```
+#Tweak the auto exposure bias
+auto_exposure_bias=15
+#Tweak the contrast
+contrast=0
+```
+
+You can edit camera.txt on-target by remounting /boot read-write:
+
+```bash
+mount -o remount,rw /boot
+```
+
 Building
 --
 Make a directory in your home: `develop`.

--- a/board/raspberrypi0cam/post-build.sh
+++ b/board/raspberrypi0cam/post-build.sh
@@ -17,3 +17,6 @@ if ! grep -qE '/var' "${TARGET_DIR}/etc/fstab"; then
 	echo 'tmpfs           /var            tmpfs   rw,mode=1777,size=64m' >> "${TARGET_DIR}/etc/fstab"
 fi
 
+if ! grep -qE '/boot' "${TARGET_DIR}/etc/fstab"; then
+	echo '/dev/mmcblk0p1  /boot           vfat    ro' >> "${TARGET_DIR}/etc/fstab"
+fi

--- a/package/piwebcam/multi-gadget.sh
+++ b/package/piwebcam/multi-gadget.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+mkdir /sys/kernel/config/usb_gadget/pi4
+
+echo 0x1d6b > /sys/kernel/config/usb_gadget/pi4/idVendor
+echo 0x0104 > /sys/kernel/config/usb_gadget/pi4/idProduct
+echo 0x0100 > /sys/kernel/config/usb_gadget/pi4/bcdDevice
+echo 0x0200 > /sys/kernel/config/usb_gadget/pi4/bcdUSB
+
+echo 0xEF > /sys/kernel/config/usb_gadget/pi4/bDeviceClass
+echo 0x02 > /sys/kernel/config/usb_gadget/pi4/bDeviceSubClass
+echo 0x01 > /sys/kernel/config/usb_gadget/pi4/bDeviceProtocol
+
+mkdir /sys/kernel/config/usb_gadget/pi4/strings/0x409
+echo 100000000d2386db > /sys/kernel/config/usb_gadget/pi4/strings/0x409/serialnumber
+echo "Show-me-webcam Project" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/manufacturer
+echo "Show-me-webcam Pi Webcam" > /sys/kernel/config/usb_gadget/pi4/strings/0x409/product
+mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2
+mkdir /sys/kernel/config/usb_gadget/pi4/configs/c.2/strings/0x409
+echo 500 > /sys/kernel/config/usb_gadget/pi4/configs/c.2/MaxPower
+echo "Show-me-webcam Pi Webcam" > /sys/kernel/config/usb_gadget/pi4/configs/c.2/strings/0x409/configuration
+
+mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0
+mkdir /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0
+mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/control/class/fs
+
+mkdir -p /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwFrameInterval
+333333
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wWidth
+1920
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/wHeight
+1080
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMinBitRate
+10000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxBitRate
+100000000
+EOF
+cat <<EOF > /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m/1080p/dwMaxVideoFrameBufferSize
+7372800
+EOF
+
+
+mkdir /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/mjpeg/m /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/class/fs
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/header/h /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0/streaming/class/hs
+
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/uvc.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.2/uvc.usb0
+ln -s /sys/kernel/config/usb_gadget/pi4/functions/acm.usb0 /sys/kernel/config/usb_gadget/pi4/configs/c.2/acm.usb0
+
+udevadm settle -t 5 || :
+ls /sys/class/udc > /sys/kernel/config/usb_gadget/pi4/UDC
+

--- a/package/piwebcam/piwebcam.mk
+++ b/package/piwebcam/piwebcam.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-PIWEBCAM_VERSION = 9a739c34513acb4933ccd1b8317dfbc140b19e02
+PIWEBCAM_VERSION = 29f6923730801980b48de444a362519728a62d7c
 PIWEBCAM_SITE = git://github.com/showmewebcam/uvc-gadget.git
 PIWEBCAM_LICENSE = GPL-2.0+
 PIWEBCAM_LICENSE_FILES = LICENSE
@@ -19,13 +19,13 @@ endef
 define PIWEBCAM_INSTALL_TARGET_CMDS
 	mkdir -p $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
 	$(INSTALL) -D -m 0755 $(@D)/uvc-gadget $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
-	$(INSTALL) -D -m 0755 $(@D)/multi-gadget.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
-	$(INSTALL) -D -m 0755 $(@D)/start-webcam.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
+	$(INSTALL) -D -m 0755 $(PIWEBCAM_PKGDIR)/multi-gadget.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
+	$(INSTALL) -D -m 0755 $(PIWEBCAM_PKGDIR)/start-webcam.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
 endef
 
 define PIWEBCAM_INSTALL_INIT_SYSTEMD
 	mkdir -p $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
-	$(INSTALL) -D -m 644 $(@D)/piwebcam.service $(TARGET_DIR)/usr/lib/systemd/system
+	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/piwebcam.service $(TARGET_DIR)/usr/lib/systemd/system
 	ln -sf /usr/lib/systemd/system/piwebcam.service $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
 endef
 

--- a/package/piwebcam/piwebcam.service
+++ b/package/piwebcam/piwebcam.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Starts pi webcam service
+
+[Service]
+ExecStart=/opt/uvc-webcam/start-webcam.sh
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=piwebcam
+WorkingDirectory=/tmp
+
+[Install]
+WantedBy=basic.target

--- a/package/piwebcam/start-webcam.sh
+++ b/package/piwebcam/start-webcam.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+/opt/uvc-webcam/multi-gadget.sh
+/usr/bin/v4l2-ctl -c auto_exposure_bias=3
+/usr/bin/v4l2-ctl -c video_bitrate=25000000
+
+CONFIG_FILE="/boot/camera.txt"
+LOGGER_TAG="piwebcam"
+
+if [ -f "$CONFIG_FILE" ] ; then
+  logger -t "$LOGGER_TAG" "Found camera.txt, applying settings"
+  #shellcheck disable=SC2002
+  cat "$CONFIG_FILE" | sed "s/ //g" | grep "\S" | grep -vE "^\#" | while read -r line
+  do
+    KEY=$(echo "$line" | cut -d= -f1)
+    VAL=$(echo "$line" | cut -d= -f2)
+    logger -t "$LOGGER_TAG" "Setting $KEY -> $VAL"
+    /usr/bin/v4l2-ctl -c "$KEY"="$VAL"
+  done
+else
+  logger -t "$LOGGER_TAG" "No camera.txt found in boot"
+fi
+
+/opt/uvc-webcam/uvc-gadget -f1 -s1 -r1  -u /dev/video1 -v /dev/video0


### PR DESCRIPTION
Also, move the uvc-webcam script to buildroot dir so that we have better
separation between uvc-webcam and its startup logic.

How to override camera settings:

Connect to the ttyACM device and issue
/usr/bin/v4l2-ctl -L | less

Then, create a file called camera.txt in /boot and put all parameters
you want overridden, for example:

auto_exposure_bias=15