### PR TITLE
Mark Pi Zero v1.3 (without Wi-Fi) as tested for HQ camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ What works and what doesn't
 
 | Raspberry Pi\Camera version  | v1 5MP  | v2 8MP  | High quality 12MP |
 | ---------------------------- | ------- | ------- | ----------------- |
-| Pi Zero v1.3 (without Wi-Fi) | &check; |         |                   |
+| Pi Zero v1.3 (without Wi-Fi) | &check; |         | &check;           |
 | Pi Zero W (with Wi-Fi)       | &check; | &check; | &check;           |
 | Pi 4+                        |         |         |                   |
 


### PR DESCRIPTION
My HQ camera finally arrived today and I was able to test the setup with RPi Zero (non-WiFi) version.
I used `v1.40` release (`sdcard-raspberry0-v1.40.img.gz`) and the camera works as expected.
Many thanks!