### PR TITLE
add default camera.txt which can be overwritten during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 output
 board/raspberrypi0
 configs/raspberrypi0_defconfig
+/camera.txt

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Make a directory in your home: `develop`.
   - `BUILDROOT_DIR=../buildroot ./build-showmewebcam.sh raspberrypi0w` to build Raspberry Pi Zero W (with Wi-Fi) image.
   - `BUILDROOT_DIR=../buildroot ./build-showmewebcam.sh raspberrypi0` to build Raspberry Pi Zero (without Wi-Fi) image.
 - The resulting image will be at the `output/` folder in the showmewebcam directory.
+- If you add a camera.txt file to the root of this repository, the contents will be automatically added to /boot/camera.txt
 
 Credits
 --

--- a/board/raspberrypi0cam/genimage-raspberrypi0.cfg
+++ b/board/raspberrypi0cam/genimage-raspberrypi0.cfg
@@ -8,6 +8,7 @@ image boot.vfat {
       "rpi-firmware/fixup.dat",
       "rpi-firmware/start.elf",
       "rpi-firmware/overlays",
+      "camera.txt",
       "zImage"
     }
   }

--- a/board/raspberrypi0cam/genimage-raspberrypi0cam.cfg
+++ b/board/raspberrypi0cam/genimage-raspberrypi0cam.cfg
@@ -8,6 +8,7 @@ image boot.vfat {
       "rpi-firmware/fixup.dat",
       "rpi-firmware/start.elf",
       "rpi-firmware/overlays",
+      "camera.txt",
       "zImage"
     }
   }

--- a/board/raspberrypi0cam/post-image.sh
+++ b/board/raspberrypi0cam/post-image.sh
@@ -74,6 +74,17 @@ __EOF__
 			sed '/^root=/ s/$/ quiet/' -i "${BINARIES_DIR}/rpi-firmware/cmdline.txt"
 		fi
 
+		# Add default camera.txt and add custom config if it exists
+		cp "$BR2_EXTERNAL_PICAM_PATH/package/piwebcam/camera.txt" "${BINARIES_DIR}/camera.txt"
+		if [ -f "$BR2_EXTERNAL_PICAM_PATH/camera.txt" ]; then
+			cat << __EOF__ >> "${BINARIES_DIR}/camera.txt"
+
+# User settings added during build
+
+__EOF__
+			cat "$BR2_EXTERNAL_PICAM_PATH/camera.txt" >> "${BINARIES_DIR}/camera.txt"
+		fi
+
 		;;
 	esac
 

--- a/package/piwebcam/camera.txt
+++ b/package/piwebcam/camera.txt
@@ -1,0 +1,7 @@
+# Default Show-me webcam camera settings
+#
+# Use v4l2-ctl -L or have a look at camera.txt.example
+# to view all possible settings
+
+auto_exposure_bias=3
+video_bitrate=25000000

--- a/package/piwebcam/start-webcam.sh
+++ b/package/piwebcam/start-webcam.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 
 /opt/uvc-webcam/multi-gadget.sh
-/usr/bin/v4l2-ctl -c auto_exposure_bias=3
-/usr/bin/v4l2-ctl -c video_bitrate=25000000
 
 CONFIG_FILE="/boot/camera.txt"
 LOGGER_TAG="piwebcam"


### PR DESCRIPTION
Create a default camera.txt and allow to overwrite it during build time by adding a camera.txt file to the root of the repository