### PR TITLE
Automatically compress image after building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,10 @@ jobs:
       - name: Build image
         run: |
           sh build-showmewebcam.sh ${{ matrix.raspberry }}
-          cp -vf output/${{ matrix.raspberry }}/images/sdcard.img sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
+          mv output/${{ matrix.raspberry }}/images/sdcard.img.gz sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v2
         with:
-          name: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
-          path: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
+          name: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img.gz
+          path: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img.gz

--- a/build-showmewebcam.sh
+++ b/build-showmewebcam.sh
@@ -31,4 +31,18 @@ case "$BOARDNAME" in
 esac
 
 BR2_EXTERNAL="$(pwd)" make O="$(pwd)/output/$BOARDNAME" -C "$BUILDROOT_DIR" "$target_defconfig"
-make -s -C "output/$BOARDNAME" all
+
+
+OUTPUT_IMG=output/"$BOARDNAME"/images/sdcard.img
+
+# gzip will ask interactively to overwrite if the file already exists
+# so let's remove the output file now
+# we can ask gzip to not ask but the -f flag is more overreaching than
+# just not asking to overwrite, so let's play it safe here
+
+if [ -f "$OUTPUT_IMG".gz ] ; then
+	rm  "$OUTPUT_IMG".gz
+fi
+
+make -s -C "output/$BOARDNAME" all \
+	&& gzip -9 "$OUTPUT_IMG"


### PR DESCRIPTION
To save github some space and bandwidth and to help with our
unwillingness to have to compress the images manually, automatically
compress the resulting image after building.

Also, change the copy directive from the workflow to a move, it's faster
to move than to copy.