### PR TITLE
Fix /boot parition size for pi0w

### DIFF
--- a/board/raspberrypi0cam/genimage-raspberrypi0cam.cfg
+++ b/board/raspberrypi0cam/genimage-raspberrypi0cam.cfg
@@ -12,7 +12,7 @@ image boot.vfat {
       "zImage"
     }
   }
-  size = 32M
+  size = 16M
 }
 
 image sdcard.img {


### PR DESCRIPTION
The pi0w board is actually called pi0cam, so the PR#52 does not actually
change its boot partition size. Now fix the pi0w boot partition size for
real.