### PR TITLE
Updated readme with Mac OS example

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ crw-rw---- 1 root dialout 166, 0 sep 25 14:03 /dev/ttyACM0
 $ sudo screen /dev/ttyACM0 115200
 ```
 
+Mac OS example:
+```
+$ ls /dev/tty.*
+crw-rw-rw-  1 root  wheel    9,  18 Dec  7 13:14 /dev/tty.usbmodem13103
+$ screen /dev/tty.usbmodem13103 115200
+```
+
 If the terminal get blank try pressing enter to see the login prompt.
 
 This interface is perhaps more helpful if you can't get the Pi to boot fully, because the serial-over-usb interface


### PR DESCRIPTION
`ll` command doesn't exist on MacOS.

Also, I didn't need to run sudo to use `screen`, don't know if that's necessary for sure or not.