### PR TITLE
piwebcam: Specify full target path to install command

### DIFF
--- a/package/piwebcam/piwebcam.mk
+++ b/package/piwebcam/piwebcam.mk
@@ -25,7 +25,7 @@ endef
 
 define PIWEBCAM_INSTALL_INIT_SYSTEMD
 	mkdir -p $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
-	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/piwebcam.service $(TARGET_DIR)/usr/lib/systemd/system
+	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/piwebcam.service $(TARGET_DIR)/usr/lib/systemd/system/piwebcam.service
 	ln -sf /usr/lib/systemd/system/piwebcam.service $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
 endef
 


### PR DESCRIPTION
This is needed to be able to build buildroot with
BR2_PER_PACKAGE_DIRECTORIES. Otherwise piwebcam.service would get
installed as the file /usr/lib/systemd/system rather than as a file
under /usr/lib/systemd/system/ since this directory did not already
exist when building with per-package directories.

Note the man page line about the -D option for install(1):

    create all leading components of DEST *except the last*