### PR TITLE
Separate usb-gadget-config logic from uvc-webcam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 buildroot
 output
+/enable-serial-debug
 /camera.txt
 configs/*_defconfig
 board/linux.config

--- a/README.md
+++ b/README.md
@@ -82,9 +82,27 @@ $ screen /dev/tty.usbmodem13103 115200
 If the terminal is blank try pressing enter to see the login prompt. To exit
 the session, use `Ctrl-A \` (screen) or `Ctrl-A X` (minicom & picocom).
 
-**ATTENTION**: This interface is not really helpful if the Raspberry Pi didn't
-boot fully, as the serial-over-USB interface only comes up when uvc-gadget
-starts.
+**Warning**: This serial debug interface is automatically enabled and is controlled
+by the file called `enable-serial-debug` in the `/boot` folder. This is a potential
+security issue. For now, you should strongly consider disabling this feature by
+removing the file after you have finished customizing the webcam.
+
+
+### My camera doesn't show up on my host computer! What to do?
+
+From version 1.80, on Linux, you can see what happens by watching `dmesg`
+before you plug in the webcam:
+
+```
+$ sudo dmesg -w
+```
+
+If you only see the `ttyACM` device show up, but not the webcam, it's likely you
+have not plugged in the camera cable correctly, or the camera cable has gone bad.
+
+If you see nothing, maybe your USB cable is bad, or you have plugged in the cable
+to the wrong port.
+
 
 ## Customizing camera settings
 

--- a/board/genimage-raspberrypi0.cfg
+++ b/board/genimage-raspberrypi0.cfg
@@ -9,6 +9,7 @@ image boot.vfat {
       "rpi-firmware/start.elf",
       "rpi-firmware/overlays",
       "camera.txt",
+      "enable-serial-debug",
       "zImage"
     }
   }

--- a/board/genimage-raspberrypi0w.cfg
+++ b/board/genimage-raspberrypi0w.cfg
@@ -9,6 +9,7 @@ image boot.vfat {
       "rpi-firmware/start.elf",
       "rpi-firmware/overlays",
       "camera.txt",
+      "enable-serial-debug",
       "zImage"
     }
   }

--- a/board/post-image.sh
+++ b/board/post-image.sh
@@ -90,6 +90,17 @@ __EOF__
 			cat "$BR2_EXTERNAL_PICAM_PATH/camera.txt" >> "${BINARIES_DIR}/camera.txt"
 		fi
 
+		# Add default enable-serial-debug file
+		cat << __EOF__ >> "${BINARIES_DIR}/enable-serial-debug"
+# This file signifies that you want to enable the serial debug console
+# via the USB port. Once you have configured the webcam to your needs
+# it is recommended that you delete this file. This action ensures that
+# your webcam's firmware won't be changed by the host computer's software.
+#
+# In the future, we will not place this file here by default, instead you'll
+# have to manually create this file if you want to access the console.
+__EOF__
+
 		;;
 	esac
 

--- a/package/piwebcam/Config.in
+++ b/package/piwebcam/Config.in
@@ -1,7 +1,7 @@
 config BR2_PACKAGE_PIWEBCAM
-	bool "Raspberry Pi Webcam"
+	bool "Raspberry Pi UVC Webcam"
 	select BR2_PACKAGE_LIBV4L_UTILS
 	help
-	  Install Raspberry Pi Webcam package
+	  Install Raspberry Pi UVC Webcam package
 
-	  https://github.com/showmewebcam/uvc-gadget
+	  https://github.com/peterbay/uvc-gadget

--- a/package/piwebcam/multi-gadget.sh
+++ b/package/piwebcam/multi-gadget.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Eventually we want to disable the serial interface by default
+# As it can be used as a persistence exploitation vector
+CONFIGURE_USB_SERIAL=false
+CONFIGURE_USB_WEBCAM=true
+
+# Now apply settings from the boot config
+if [ -f "/boot/enable-serial-debug" ] ; then
+  CONFIGURE_USB_SERIAL=true
+fi
+
 CONFIG=/sys/kernel/config/usb_gadget/piwebcam
 mkdir -p "$CONFIG"
 cd "$CONFIG" || exit 1
@@ -19,12 +29,14 @@ mkdir -p configs/c.2
 mkdir -p configs/c.2/strings/0x409
 echo 100000000d2386db         > strings/0x409/serialnumber
 echo "Show-me Webcam Project" > strings/0x409/manufacturer
-echo "Piwebcam "              > strings/0x409/product
+echo "Piwebcam"               > strings/0x409/product
 echo 500                      > configs/c.2/MaxPower
 echo "Piwebcam"               > configs/c.2/strings/0x409/configuration
 
-mkdir -p functions/uvc.usb0/control/header/h
-mkdir -p functions/acm.usb0
+config_usb_serial () {
+  mkdir -p functions/acm.usb0
+  ln -s functions/acm.usb0 configs/c.2/acm.usb0
+}
 
 config_frame () {
   FORMAT=$1
@@ -39,9 +51,9 @@ config_frame () {
   echo "$WIDTH"                    > "$FRAMEDIR"/wWidth
   echo "$HEIGHT"                   > "$FRAMEDIR"/wHeight
   echo 333333                      > "$FRAMEDIR"/dwDefaultFrameInterval
-  echo $(($WIDTH * $HEIGHT * 80))  > "$FRAMEDIR"/dwMinBitRate
-  echo $(($WIDTH * $HEIGHT * 160)) > "$FRAMEDIR"/dwMaxBitRate
-  echo $(($WIDTH * $HEIGHT * 2))   > "$FRAMEDIR"/dwMaxVideoFrameBufferSize
+  echo $((WIDTH * HEIGHT * 80))  > "$FRAMEDIR"/dwMinBitRate
+  echo $((WIDTH * HEIGHT * 160)) > "$FRAMEDIR"/dwMaxBitRate
+  echo $((WIDTH * HEIGHT * 2))   > "$FRAMEDIR"/dwMaxVideoFrameBufferSize
   cat <<EOF > "$FRAMEDIR"/dwFrameInterval
 333333
 400000
@@ -49,26 +61,45 @@ config_frame () {
 EOF
 }
 
-config_frame mjpeg m  640  360
-config_frame mjpeg m  640  480
-config_frame mjpeg m  800  600
-config_frame mjpeg m 1024  768
-config_frame mjpeg m 1280  720
-config_frame mjpeg m 1280  960
-config_frame mjpeg m 1440 1080
-config_frame mjpeg m 1536  864
-config_frame mjpeg m 1600  900
-config_frame mjpeg m 1600 1200
-config_frame mjpeg m 1920 1080
+config_usb_webcam () {
+  mkdir -p functions/uvc.usb0/control/header/h
 
-mkdir -p functions/uvc.usb0/streaming/header/h
-ln -s functions/uvc.usb0/streaming/mjpeg/m  functions/uvc.usb0/streaming/header/h
-ln -s functions/uvc.usb0/streaming/header/h functions/uvc.usb0/streaming/class/fs
-ln -s functions/uvc.usb0/streaming/header/h functions/uvc.usb0/streaming/class/hs
-ln -s functions/uvc.usb0/control/header/h   functions/uvc.usb0/control/class/fs
+  config_frame mjpeg m  640  360
+  config_frame mjpeg m  640  480
+  config_frame mjpeg m  800  600
+  config_frame mjpeg m 1024  768
+  config_frame mjpeg m 1280  720
+  config_frame mjpeg m 1280  960
+  config_frame mjpeg m 1440 1080
+  config_frame mjpeg m 1536  864
+  config_frame mjpeg m 1600  900
+  config_frame mjpeg m 1600 1200
+  config_frame mjpeg m 1920 1080
 
-ln -s functions/uvc.usb0 configs/c.2/uvc.usb0
-ln -s functions/acm.usb0 configs/c.2/acm.usb0
+  mkdir -p functions/uvc.usb0/streaming/header/h
+  ln -s functions/uvc.usb0/streaming/mjpeg/m  functions/uvc.usb0/streaming/header/h
+  ln -s functions/uvc.usb0/streaming/header/h functions/uvc.usb0/streaming/class/fs
+  ln -s functions/uvc.usb0/streaming/header/h functions/uvc.usb0/streaming/class/hs
+  ln -s functions/uvc.usb0/control/header/h   functions/uvc.usb0/control/class/fs
+
+  ln -s functions/uvc.usb0 configs/c.2/uvc.usb0
+}
+
+# Check if camera is installed correctly
+if [ ! -e /dev/video0 ] ; then
+  echo "I did not detect a camera connected to the Pi. Please check your hardware."
+  CONFIGURE_USB_WEBCAM=false
+fi
+
+if [ "$CONFIGURE_USB_WEBCAM" = true ] ; then
+  echo "Configuring USB gadget webcam interface"
+  config_usb_webcam
+fi
+
+if [ "$CONFIGURE_USB_SERIAL" = true ] ; then
+  echo "Configuring USB gadget serial interface"
+  config_usb_serial
+fi
 
 udevadm settle -t 5 || :
 ls /sys/class/udc > UDC

--- a/package/piwebcam/piwebcam.mk
+++ b/package/piwebcam/piwebcam.mk
@@ -25,8 +25,10 @@ endef
 
 define PIWEBCAM_INSTALL_INIT_SYSTEMD
 	mkdir -p $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
-	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/piwebcam.service $(TARGET_DIR)/usr/lib/systemd/system/piwebcam.service
-	ln -sf /usr/lib/systemd/system/piwebcam.service $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
+	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/uvc-webcam.service $(TARGET_DIR)/usr/lib/systemd/system/uvc-webcam.service
+	$(INSTALL) -D -m 644 $(PIWEBCAM_PKGDIR)/usb-gadget-config.service $(TARGET_DIR)/usr/lib/systemd/system/usb-gadget-config.service
+	ln -sf /usr/lib/systemd/system/uvc-webcam.service $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
+	ln -sf /usr/lib/systemd/system/usb-gadget-config.service $(TARGET_DIR)/etc/systemd/system/$(PIWEBCAM_INIT_SYSTEMD_TARGET)
 endef
 
 $(eval $(generic-package))

--- a/package/piwebcam/start-webcam.sh
+++ b/package/piwebcam/start-webcam.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
-/opt/uvc-webcam/multi-gadget.sh
-
 CONFIG_FILE="/boot/camera.txt"
 LOGGER_TAG="piwebcam"
+
+if [ ! -e /dev/video0 ] || [ ! -e /dev/video1 ] ; then
+  logger -t "$LOGGER_TAG" "One video device is missing, will not start uvc-webcam"
+  exit 1
+fi
 
 if [ -f "$CONFIG_FILE" ] ; then
   logger -t "$LOGGER_TAG" "Found camera.txt, applying settings"

--- a/package/piwebcam/usb-gadget-config.service
+++ b/package/piwebcam/usb-gadget-config.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Configure Raspberry Pi as a USB gadget
+
+[Service]
+Type=oneshot
+ExecStart=/opt/uvc-webcam/multi-gadget.sh
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=usb-gadget-config
+WorkingDirectory=/tmp
+
+[Install]
+WantedBy=basic.target

--- a/package/piwebcam/uvc-webcam.service
+++ b/package/piwebcam/uvc-webcam.service
@@ -1,5 +1,6 @@
 [Unit]
-Description=Starts pi webcam service
+Description=Starts Raspberry Pi UVC webcam service
+After=usb-gadget-config.service
 
 [Service]
 ExecStart=/opt/uvc-webcam/start-webcam.sh


### PR DESCRIPTION
- Separate the logic to initialize usb gadget from uvc-webcam.
- Allow usb serial to be functional when uvc-webcam can't start up.
- Allow user to edit the usb-gadget.txt file to disable serial
access to the Pi.