### PR TITLE
Github actions: Cache buildroot

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,19 +42,23 @@ jobs:
           echo "GIT_TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "Current version: $(git describe)"
 
+      - name: Cache Build
+        id: restore-cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            output
+            buildroot
+          # Stupid hack to invalidate cache from UI
+          # https://github.com/actions/cache/issues/2#issuecomment-673493515
+          key: ${{ matrix.raspberry }}-${{ env.BUILDROOT_DIR }}-${{ env.BUILDROOT_VERSION }}-${{ secrets.CACHE_VERSION }}
+
       - name: Download Buildroot
+        if: steps.restore-cache.outputs.cache-hit != 'true'
         run: |
           wget -qc https://buildroot.org/downloads/buildroot-${{ env.BUILDROOT_VERSION }}.tar.gz
           tar -zxf buildroot-${{ env.BUILDROOT_VERSION }}.tar.gz
           mv buildroot-${{ env.BUILDROOT_VERSION }} ${{ env.BUILDROOT_DIR }}
-
-      - name: Cache Build
-        uses: actions/cache@v2
-        with:
-          path: output
-          # Stupid hack to invalidate cache from UI
-          # https://github.com/actions/cache/issues/2#issuecomment-673493515
-          key: ${{ matrix.raspberry }}-${{ env.BUILDROOT_DIR }}-${{ env.BUILDROOT_VERSION }}-${{ secrets.CACHE_VERSION }}
 
       - name: Build Image
         run: |


### PR DESCRIPTION
Currently, every time we build, we hammer the server of our
good friends at Buildroot project. We should not do that, and cache
our extracted tarball.