### PR TITLE
Github actions: Run shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,27 @@
+name: Shellcheck
+
+on:
+  # Triggers the workflow on push or pull request events on the master branch
+  pull_request:
+    branches: [ master ]
+
+  # Allows to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Shellcheck all scripts
+        run: |
+          shellcheck $(git ls-files '*.sh')

--- a/board/post-image.sh
+++ b/board/post-image.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-GENIMAGE_CFG="$(dirname $0)/genimage-${BOARDNAME}.cfg"
+GENIMAGE_CFG="$(dirname "$0")/genimage-${BOARDNAME}.cfg"
 GENIMAGE_TMP="${BUILD_DIR}/genimage.tmp"
 
 for arg in "$@"


### PR DESCRIPTION
- Run shellcheck on PRs and releases to prevent silly shell mistakes

- Fix post-image shellcheck warning