### PR TITLE
Enable additional UVC control settings

### DIFF
--- a/patches/linux-custom/0002-linux-enable-even-more-video-controls.patch
+++ b/patches/linux-custom/0002-linux-enable-even-more-video-controls.patch
@@ -1,0 +1,22 @@
+diff --git a/drivers/usb/gadget/function/f_uvc.c b/drivers/usb/gadget/function/f_uvc.c
+index 5c850be..5a9ec10 100644
+--- a/drivers/usb/gadget/function/f_uvc.c
++++ b/drivers/usb/gadget/function/f_uvc.c
+@@ -802,7 +802,7 @@ static struct usb_function_instance *uvc_alloc_inst(void)
+        cd->wObjectiveFocalLengthMax    = cpu_to_le16(0);
+        cd->wOcularFocalLength          = cpu_to_le16(0);
+        cd->bControlSize                = 3;
+-       cd->bmControls[0]               = 2;
++       cd->bmControls[0]               = 14;
+        cd->bmControls[1]               = 0;
+        cd->bmControls[2]               = 0;
+ 
+@@ -815,7 +815,7 @@ static struct usb_function_instance *uvc_alloc_inst(void)
+        pd->wMaxMultiplier              = cpu_to_le16(16*1024);
+        pd->bControlSize                = 2;
+        pd->bmControls[0]               = 255;
+-       pd->bmControls[1]               = 6;
++       pd->bmControls[1]               = 47;
+        pd->iProcessing                 = 0;
+ 
+        od = &opts->uvc_output_terminal;

--- a/patches/linux-custom/0002-linux-enable-even-more-video-controls.patch
+++ b/patches/linux-custom/0002-linux-enable-even-more-video-controls.patch
@@ -3,20 +3,20 @@ index 5c850be..5a9ec10 100644
 --- a/drivers/usb/gadget/function/f_uvc.c
 +++ b/drivers/usb/gadget/function/f_uvc.c
 @@ -802,7 +802,7 @@ static struct usb_function_instance *uvc_alloc_inst(void)
-        cd->wObjectiveFocalLengthMax    = cpu_to_le16(0);
-        cd->wOcularFocalLength          = cpu_to_le16(0);
-        cd->bControlSize                = 3;
--       cd->bmControls[0]               = 2;
-+       cd->bmControls[0]               = 14;
-        cd->bmControls[1]               = 0;
-        cd->bmControls[2]               = 0;
+ 	cd->wObjectiveFocalLengthMax	= cpu_to_le16(0);
+ 	cd->wOcularFocalLength		= cpu_to_le16(0);
+ 	cd->bControlSize		= 3;
+-	cd->bmControls[0]		= 2;
++	cd->bmControls[0]		= 14;
+ 	cd->bmControls[1]		= 0;
+ 	cd->bmControls[2]		= 0;
  
 @@ -815,7 +815,7 @@ static struct usb_function_instance *uvc_alloc_inst(void)
-        pd->wMaxMultiplier              = cpu_to_le16(16*1024);
-        pd->bControlSize                = 2;
-        pd->bmControls[0]               = 255;
--       pd->bmControls[1]               = 6;
-+       pd->bmControls[1]               = 47;
-        pd->iProcessing                 = 0;
+ 	pd->wMaxMultiplier		= cpu_to_le16(16*1024);
+ 	pd->bControlSize		= 2;
+ 	pd->bmControls[0]		= 255;
+-	pd->bmControls[1]		= 6;
++	pd->bmControls[1]		= 47;
+ 	pd->iProcessing			= 0;
  
-        od = &opts->uvc_output_terminal;
+ 	od = &opts->uvc_output_terminal;


### PR DESCRIPTION
This PR adds a patch file that enables all UVC video settings in the USB descriptor for which V4L2 mappings exist in `uvc-gadget`, though not all settings are fully functional, yet (neither are all settings functional with the 0001 patch).

Camera Terminal in uvc-gadget maps 0x0E / 14, 0x00, 0x00
D1 AE_MODE
D2 AE_PRIORITY
D3 exposure time

Processing Unit in uvc-gadget maps 0xFF / 255,  0x2F / 47, 0x00
D0 Brightness
D1 contrast
D2 hue
D3 saturation
D4 sharpness
D5 gamma
D6 WB temperature
D7 WB component

D8 Backlight compensation
D9 gain
D10 flicker
D11 auto hue
D13 WB component auto maps to V4L2 auto WB
