### PR TITLE
A camera control script that automates running camera-ctl 

### DIFF
--- a/picamctl/picamctl.sh
+++ b/picamctl/picamctl.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# akseidel 02/06/2021
+# A script automating the steps to run showmewencam's "camera-ctl".
+
+# The script will pause for continue or exit if run with an argument.
+debugpause=$1 
+# edit this next line to be the correct text pattern for your computer.
+portnamepat="tty.usbmodem*" #typical for showmewebcam on Appl OS X
+#portnamepat="ttyACM*" #probably typical for showmewebcam on Linux
+#portnamepat="tty.*"
+# The client is an application you want this script to also run. 
+runtheclient="true"
+clientname="Photo Booth"
+
+# initial cleanup
+initclean(){
+    reset
+    clear
+    # terminates all the ort screen sessions.
+    screen -ls | grep Attached | cut -d. -f1 | awk '{print $1}' | xargs kill
+    screen -ls | grep Detached | cut -d. -f1 | awk '{print $1}' | xargs kill
+}
+
+# run the client application
+runclient(){
+    if [ "$runtheclient" = "true" ]; then
+        # -g causes application to open in background 
+        # https://scriptingosx.com/2017/02/the-macos-open-command/
+        open -g -a "$clientname"
+    fi
+}
+
+# start the screen session
+doscreensession(){
+    echo ""
+    echo "Now establishing serial connection using 'screen' ..."
+    # For some reason screen stuffing the user, password and camera-ctl to
+    # a detached target screen does not work without the target screen having
+    # been attached at some point. Here the nest screen into a spawner screen
+    # trick is used to get around that.   
+    screen -dmS spawner
+    screen -S spawner -X screen screen -dR thispicam $piusbwebcamport 115200
+    sleep 0.3
+    screen -S thispicam -X detach
+    sleep 0.3
+    screen -S thispicam -X stuff $'root\n'
+    sleep 0.3
+    screen -S thispicam -X stuff $'root\n'
+    sleep 0.3
+    screen -S thispicam -X stuff $'camera-ctl\n'
+    screen -r thispicam
+}
+
+# show intro text
+showintro(){
+    echo "======================================================================"   
+    echo "                             picamctl                                 "
+    echo "======================================================================"       
+    echo "  This script looks for a serial port device that could be the        "  
+    echo "  Showmewebcam USB webcam device. It will connect to the device, log  "
+    echo "  in as root and then run the camera settings control utility.        " 
+    echo "----------------------------------------------------------------------"
+    echo "  Looking for a device like: /dev/$portnamepat                        "
+}
+
+# collect the port names
+getportnames(){
+    serialportlist=$(ls -a /dev/$portnamepat 2> /dev/null)
+    countofserialportslist=$(ls -a /dev/$portnamepat  2> /dev/null | wc -l)
+}
+
+# report port qty
+rptportqty(){
+    echo "  $(expr $countofserialportslist + 0) such ports found."
+}
+
+# report ports
+rptportlist(){
+    echo " " $serialportlist 2> /dev/null
+}
+
+# set port to use and show it
+dosetport(){
+    # changes item space separator to a newline and returns tail item
+    piusbwebcamport=$(echo "$serialportlist" | tr ' ' '\n' | tail -1)
+    echo "  Assuming this last one => " $piusbwebcamport
+    echo "======================================================================"
+}
+
+# option for pause and exit if any argument present, for diagnostic use
+option2exit(){
+    if [ ! -z "$1" ]
+    then
+        while read -r -s -p "Press any key when ready to continue. (ESC key quits)" -n1 key 
+        do
+            # check for escape key
+            if [[ $key == $'\e' ]]; then
+                echo ""
+                echo "Ok, Bye"
+                exit 0
+            else
+                break
+            fi
+        done
+    fi
+}
+
+# checkboot status
+checkbootstatus(){
+while [ $countofserialportslist = 0 ]
+    do
+        echo ""
+        echo "  None found! Got that USB thing plugged in or waited the 10 seconds"
+        echo "  needed for booting up? Periodic boot checking is now happening."
+        echo "======================================================================"
+        echo ""
+        chk=1
+        chklim=12
+        while [ $chk -le $chklim ]
+            do
+                echo -ne "  Checking for a ready showmewebcam. Attempt $chk out of $chklim  ... \r"
+                getportnames
+                if [ $countofserialportslist != 0 ]; then
+                    break 2
+                fi
+                chk=$(( $chk + 1 ))
+                sleep 2
+            done
+        echo -e "  Run this again when the camera is ready.                             "
+        echo ""
+        exit 
+    done
+}
+
+# program section
+
+initclean
+showintro
+getportnames
+rptportqty   
+checkbootstatus
+rptportlist
+dosetport
+option2exit $1
+runclient
+doscreensession
+
+# end        

--- a/picamctl/picamctl_README.md
+++ b/picamctl/picamctl_README.md
@@ -1,0 +1,41 @@
+# ScriptsForShowMeWebCam
+
+## picamctl.sh
+
+The USB Raspberry Pi Zero showmewebcam is a plug-in-and-it-works webcam system whereas running the showmewebcam camera settings utility program, "camera-ctl", requires arcane technical skills to perform a multistep process. The **picamctl.sh** script performs all the required steps for you.
+
+**picamctl.sh** automates the following:
+* Determines the USB connected Raspberry Pi Zero showmewebcam's most likely serial device port name.
+* Establishes a 115200 baud serial connection to the Raspberry Pi Zero showmewebcam in a screen session.
+* Logs into the Raspberry Pi Zero showmewebcam as root.
+* Starts the showmewebcam system's "camera-ctl" utility.
+
+**picamctl.sh** also does the following:
+
+- Starts Apple's PhotoBooth application. Alter or remove that feature from the script as needed.
+- Removes all existing Attached and Detached screen instances. Unused screen instances are typically left over by the method used to run "camera-ctl". Alter or remove this feature as needed if you have other screen instances you need to remain.
+
+**How To Use**
+
+**picamctl.sh** is made for use on an Apple OS X computer. It probably works on a Linux machine with an edit to remove or change the PhotoBooth feature and with also an edit to change the device name discovery pattern. Similar alterations probably would be required for it to work on a Windows machine. Look online to explain how to perform any unfamiliar step mentioned below.
+
+* Download **picamctl.sh** to your computer.
+
+**Starting Up**
+* Open a Terminal window.
+* In the Terminal window change the current directory to be the one where you copied **picamctl.sh**.
+* Plug the Raspberry Pi Zero showmewebcam webcam system USB cable into the computer.
+* In the Terminal window type in "**./picamctl.sh**" or "**bash ./picamctl.sh**".
+* If showmewebcam has yet to finish booting, **picamctl.sh** will make a number of attempts to check for a late startup. 
+* The Terminal window should now be logged into the Raspberry Pi Zero showmewebcam system and showing the camera control interface.
+
+**Shut Down**
+* Unplug the Raspberry Pi Zero showmewebcam webcam system USB cable from the computer. Unplugging the device powers off the Pi Zero. This is an important step that you might eventually learn the hard way because just terminating the Terminal session without shutting down the Pi Zero leaves the Pi Zero either still running the camera control utility or running in some other unexpected state. Running **picamctl.sh** under those circumstances results in a confused looking screen session.
+* Close out the Terminal window.
+
+**Details and Comments**
+* picamctl.sh currently runs under bash. It uses a keystroke test routine that does not work in zsh.
+* When **picamctl.sh** is started with any argument, for example "**./picamctl.sh  p**", the script pauses for confirmation instead of starting to make the serial connection. This mode can be used for troubleshooting the serial device name it has selected to use for the connection.
+
+**Showmewebcam is found at:**
+<https://github.com/showmewebcam/showmewebcam>


### PR DESCRIPTION
This is a shell script with accompanying instruction readme that performs all tasks required to start camera-ctl in a Terminal session.

This script when executed in a Terminal window finishes up with "camera-ctl" running in a screen session. It automates the serial connection after detecting the tty serial device presence, logs in as root and runs "camera-ctl".

Although the showmewebcam readme describes "camera-ctl" in debugging it is actually an essential utility required to be running when showmewebcam is being used in dynamic situations. This script allows ordinary users to easily invoke "camera-ctl".