### PR TITLE
Multi gadget fixes

### DIFF
--- a/package/piwebcam/multi-gadget.sh
+++ b/package/piwebcam/multi-gadget.sh
@@ -89,6 +89,8 @@ config_usb_webcam () {
 if [ ! -e /dev/video0 ] ; then
   echo "I did not detect a camera connected to the Pi. Please check your hardware."
   CONFIGURE_USB_WEBCAM=false
+  # Nobody can read the error if we don't have serial enabled!
+  CONFIGURE_USB_SERIAL=true
 fi
 
 if [ "$CONFIGURE_USB_WEBCAM" = true ] ; then

--- a/package/piwebcam/multi-gadget.sh
+++ b/package/piwebcam/multi-gadget.sh
@@ -101,5 +101,7 @@ if [ "$CONFIGURE_USB_SERIAL" = true ] ; then
   config_usb_serial
 fi
 
-udevadm settle -t 5 || :
 ls /sys/class/udc > UDC
+
+# Ensure any configfs changes are picked up
+udevadm settle -t 5 || :

--- a/package/piwebcam/usb-gadget-config.service
+++ b/package/piwebcam/usb-gadget-config.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Configure Raspberry Pi as a USB gadget
+After=systemd-udev-settle.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Ensure udev has settled before we setup the gadget, on the Pi 4 at least this is nice to have, although probably not needed (when camera support is built as a module I've still had it show up late).

Also make sure to enable serial so that logs can be retrieved if we fail to find a camera.