### PR TITLE
Set processing controls from cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ You can edit `camera.txt` on-target by remounting `/boot` read-write:
 mount -o remount,rw /boot
 ```
 
+### Overriding the controls available to the host computer
+
+Since version 1.80 we try to expose as many controls as possible via the UVC
+standard, which are then translated back to the controls that are available
+on your specific camera module. Some host operating systems may be confused
+by controls that are advertised via USB, but don't turn out to work, due to
+not being available for your specific camera module.
+
+You can therefore customize the controls advertised to the computer via the
+USB device descriptor. *Warning*: This is an advanced user feature only.
+You should probably consult the [UVC controls bitmap documentation] on GitHub.
+
+You can add the parameters to `cmdline.txt` on the boot volume as follows:
+
+```
+usb_f_uvc.camera_terminal_controls=0,0,0 usb_f_uvc.processing_unit_controls=0,0
+```
+
+The previous example sets all controls to disabled, and should thus be safe.
+The parameters directly correspond to the `bmControls` bitfields in the descriptor.
+Please, again, read the documentation linked above.
+
 ## Development & building
 
 Clone or download this repository. Then inside it:
@@ -175,3 +197,5 @@ Clone or download this repository. Then inside it:
 - ARM fever: https://armphibian.wordpress.com/2019/10/01/how-to-build-raspberry-pi-zero-w-buildroot-image/
 - The repository icon is attributed to the GNOME project
 
+
+[UVC controls bitmap documentation]: https://github.com/showmewebcam/showmewebcam/wiki/UVC-Controls

--- a/patches/linux-custom/0001-linux-enable-more-video-controls.patch
+++ b/patches/linux-custom/0001-linux-enable-more-video-controls.patch
@@ -2,14 +2,25 @@ diff --git a/drivers/usb/gadget/function/f_uvc.c b/drivers/usb/gadget/function/f
 index fb0a892..5c850be 100644
 --- a/drivers/usb/gadget/function/f_uvc.c
 +++ b/drivers/usb/gadget/function/f_uvc.c
-@@ -814,8 +814,8 @@ static struct usb_function_instance *uvc_alloc_inst(void)
+@@ -34,6 +34,10 @@
+ module_param_named(trace, uvc_gadget_trace_param, uint, 0644);
+ MODULE_PARM_DESC(trace, "Trace level bitmask");
+ 
++unsigned int uvc_gadget_processing_controls[2] = {255, 6};
++module_param_array_named(bm_controls, uvc_gadget_processing_controls, uint, NULL, 0644);
++MODULE_PARM_DESC(bm_controls, "Processing control availabilty bitfield");
++
+ /* --------------------------------------------------------------------------
+  * Function descriptors
+  */
+@@ -814,8 +818,8 @@
  	pd->bSourceID			= 1;
  	pd->wMaxMultiplier		= cpu_to_le16(16*1024);
  	pd->bControlSize		= 2;
 -	pd->bmControls[0]		= 1;
 -	pd->bmControls[1]		= 0;
-+	pd->bmControls[0]		= 255;
-+	pd->bmControls[1]		= 6;
++	pd->bmControls[0]		= uvc_gadget_processing_controls[0];
++	pd->bmControls[1]		= uvc_gadget_processing_controls[1];
  	pd->iProcessing			= 0;
  
  	od = &opts->uvc_output_terminal;

--- a/patches/linux-custom/0001-linux-enable-more-video-controls.patch
+++ b/patches/linux-custom/0001-linux-enable-more-video-controls.patch
@@ -2,22 +2,28 @@ diff --git a/drivers/usb/gadget/function/f_uvc.c b/drivers/usb/gadget/function/f
 index fb0a892..5c850be 100644
 --- a/drivers/usb/gadget/function/f_uvc.c
 +++ b/drivers/usb/gadget/function/f_uvc.c
-@@ -34,6 +34,14 @@
+@@ -34,6 +34,20 @@
  module_param_named(trace, uvc_gadget_trace_param, uint, 0644);
  MODULE_PARM_DESC(trace, "Trace level bitmask");
  
 +unsigned int uvc_gadget_camera_terminal_controls[3] = {2, 0, 0};
-+module_param_array_named(camera_controls, uvc_gadget_camera_terminal_controls, uint, NULL, 0644);
-+MODULE_PARM_DESC(camera_controls, "Camera control availabilty bitfield");
++module_param_array_named(camera_terminal_controls, \
++		uvc_gadget_camera_terminal_controls, \
++		uint, NULL, 0644);
++MODULE_PARM_DESC(camera_terminal_controls, \
++		"Camera terminal control availabilty bitfield");
 +
-+unsigned int uvc_gadget_processing_controls[2] = {255, 6};
-+module_param_array_named(proc_controls, uvc_gadget_processing_controls, uint, NULL, 0644);
-+MODULE_PARM_DESC(proc_controls, "Processing control availabilty bitfield");
++unsigned int uvc_gadget_processing_unit_controls[2] = {255, 6};
++module_param_array_named(processing_unit_controls, \
++		uvc_gadget_processing_unit_controls, \
++		uint, NULL, 0644);
++MODULE_PARM_DESC(processing_unit_controls, \
++		"Processing unit control availabilty bitfield");
 +
  /* --------------------------------------------------------------------------
   * Function descriptors
   */
-@@ -802,9 +810,9 @@
+@@ -802,9 +816,9 @@
  	cd->wObjectiveFocalLengthMax	= cpu_to_le16(0);
  	cd->wOcularFocalLength		= cpu_to_le16(0);
  	cd->bControlSize		= 3;
@@ -30,14 +36,14 @@ index fb0a892..5c850be 100644
  
  	pd = &opts->uvc_processing;
  	pd->bLength			= UVC_DT_PROCESSING_UNIT_SIZE(2);
-@@ -814,8 +822,8 @@
+@@ -814,8 +828,8 @@
  	pd->bSourceID			= 1;
  	pd->wMaxMultiplier		= cpu_to_le16(16*1024);
  	pd->bControlSize		= 2;
 -	pd->bmControls[0]		= 1;
 -	pd->bmControls[1]		= 0;
-+	pd->bmControls[0]		= uvc_gadget_processing_controls[0];
-+	pd->bmControls[1]		= uvc_gadget_processing_controls[1];
++	pd->bmControls[0]		= uvc_gadget_processing_unit_controls[0];
++	pd->bmControls[1]		= uvc_gadget_processing_unit_controls[1];
  	pd->iProcessing			= 0;
  
  	od = &opts->uvc_output_terminal;

--- a/patches/linux-custom/0001-linux-enable-more-video-controls.patch
+++ b/patches/linux-custom/0001-linux-enable-more-video-controls.patch
@@ -2,10 +2,14 @@ diff --git a/drivers/usb/gadget/function/f_uvc.c b/drivers/usb/gadget/function/f
 index fb0a892..5c850be 100644
 --- a/drivers/usb/gadget/function/f_uvc.c
 +++ b/drivers/usb/gadget/function/f_uvc.c
-@@ -34,6 +34,10 @@
+@@ -34,6 +34,14 @@
  module_param_named(trace, uvc_gadget_trace_param, uint, 0644);
  MODULE_PARM_DESC(trace, "Trace level bitmask");
  
++unsigned int uvc_gadget_camera_terminal_controls[3] = {2, 0, 0};
++module_param_array_named(camera_controls, uvc_gadget_camera_terminal_controls, uint, NULL, 0644);
++MODULE_PARM_DESC(camera_controls, "Camera control availabilty bitfield");
++
 +unsigned int uvc_gadget_processing_controls[2] = {255, 6};
 +module_param_array_named(proc_controls, uvc_gadget_processing_controls, uint, NULL, 0644);
 +MODULE_PARM_DESC(proc_controls, "Processing control availabilty bitfield");
@@ -13,7 +17,20 @@ index fb0a892..5c850be 100644
  /* --------------------------------------------------------------------------
   * Function descriptors
   */
-@@ -814,8 +818,8 @@
+@@ -802,9 +810,9 @@
+ 	cd->wObjectiveFocalLengthMax	= cpu_to_le16(0);
+ 	cd->wOcularFocalLength		= cpu_to_le16(0);
+ 	cd->bControlSize		= 3;
+-	cd->bmControls[0]		= 2;
+-	cd->bmControls[1]		= 0;
+-	cd->bmControls[2]		= 0;
++	cd->bmControls[0]		= uvc_gadget_camera_terminal_controls[0];
++	cd->bmControls[1]		= uvc_gadget_camera_terminal_controls[1];
++	cd->bmControls[2]		= uvc_gadget_camera_terminal_controls[2];
+ 
+ 	pd = &opts->uvc_processing;
+ 	pd->bLength			= UVC_DT_PROCESSING_UNIT_SIZE(2);
+@@ -814,8 +822,8 @@
  	pd->bSourceID			= 1;
  	pd->wMaxMultiplier		= cpu_to_le16(16*1024);
  	pd->bControlSize		= 2;

--- a/patches/linux-custom/0001-linux-enable-more-video-controls.patch
+++ b/patches/linux-custom/0001-linux-enable-more-video-controls.patch
@@ -7,8 +7,8 @@ index fb0a892..5c850be 100644
  MODULE_PARM_DESC(trace, "Trace level bitmask");
  
 +unsigned int uvc_gadget_processing_controls[2] = {255, 6};
-+module_param_array_named(bm_controls, uvc_gadget_processing_controls, uint, NULL, 0644);
-+MODULE_PARM_DESC(bm_controls, "Processing control availabilty bitfield");
++module_param_array_named(proc_controls, uvc_gadget_processing_controls, uint, NULL, 0644);
++MODULE_PARM_DESC(proc_controls, "Processing control availabilty bitfield");
 +
  /* --------------------------------------------------------------------------
   * Function descriptors


### PR DESCRIPTION
This PR moves the values for usb descriptor `bmControls` bitmap to a commandline parameter, so we can experiment what host OSes expect to see there and what actually works with the Pi cameras, without having to recompile a kernel all the time.

The Bitmap can be changed by editing `cmdline.txt` on the SD to say `usb_f_uvc.bm_controls=<byte1>,<byte2>`.

Submitting as Draft to get it out there, might not yet work on master since it might need support from [uvc-gadget](/peterbay/uvc-gadget), but should help against the issues seen in #116