### PR TITLE
Tested v2 camera on raspberry pi 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Show-me webcam is proudly powered by [peterbay's uvc-gadget](https://github.com/
 | ------------------------------ | ------- | ------- | ----------------- |
 | Pi Zero v1.3 (without Wifi)    | &check; | &check; | &check;           |
 | Pi Zero W (with Wifi)          | &check; | &check; | &check;           |
-| Pi 4+                          |         |         | &check;           |
+| Pi 4+                          |         | &check; | &check;           |
 
 ## Instructions
 


### PR DESCRIPTION
I tested an official raspberry pi v2 module with a raspberry pi 4b 4gb and it worked without any issues.
I did have to build a raspberry pi 4 image as there where no raspberry pi 4 version under releases?