### PR TITLE
Configurable resolutions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     env:
-      BUILDROOT_VERSION: '2021.02.1'
+      BUILDROOT_VERSION: '2021.02.4'
       BUILDROOT_DIR: 'buildroot'
 
     strategy:
@@ -52,6 +52,11 @@ jobs:
           # Stupid hack to invalidate cache from UI
           # https://github.com/actions/cache/issues/2#issuecomment-673493515
           key: ${{ matrix.raspberry }}-${{ env.BUILDROOT_DIR }}-${{ env.BUILDROOT_VERSION }}-${{ secrets.CACHE_VERSION }}
+
+      # Github Actions are sometimes blocked from this mirror
+      # https://github.com/actions/virtual-environments/issues/2577
+      - name: Blocked mirror workaround
+        run: echo "127.0.0.1 invisible-mirror.net" | sudo tee -a /etc/hosts
 
       - name: Download Buildroot
         if: steps.restore-cache.outputs.cache-hit != 'true'

--- a/README.md
+++ b/README.md
@@ -173,16 +173,16 @@ Please, again, read the documentation linked above.
 
 ### Configure available camera resolutions and streaming format
 
-The camera advertizes to the connected host PC the available resolutions and
-streaming formats of the video signal. Usually the best suitable resolution is
-chosen. The available resolutions can be reduced to enforce a specific setting.
+The camera advertises the available resolutions and streaming formats to the
+connected host PC. Usually the best suitable resolution is chosen. The available
+resolutions can be reduced to enforce a specific setting.
 
 By default the camera uses the *Motion JPEG* codec to stream the video signal.
 For the host PC it offers several video resolutions up to 1080p HD video to
 choose from.
 
 These settings can be overwritten by copying the file `video_formats.txt` into
-the `/boot` folder and edit it.
+the `/boot` folder and editing it.
 
 ```bash
 cp /etc/video_formats.txt /boot
@@ -190,31 +190,10 @@ cp /etc/video_formats.txt /boot
 
 In this file one line corresponds to one video resolution and streaming format.
 Until now, only mjpeg and uncompressed video are supported. If you want to make
-the lower resolutions up to 720p HD unavailable, you have to comment out the
-first 4 resultions by prepending a `#` to that line.
+certain resolutions unavailable, comment them out by prepending a `#` to that
+line or removing them altogether.
 
-Please note that you have to reboot your piwebcam (power cyle it) for changes
-to take effect.
-
-Content of `video_formats.txt`
-```
-# Default Show-me webcam supported resolutions
-#
-# format: video format(mjpeg|uncompressed) x-dimension y-dimension
-#
-mjpeg 640 360
-mjpeg 640 480
-mjpeg 800 600
-mjpeg 1024 768
-mjpeg 1280 720
-mjpeg 1280 960
-mjpeg 1440 1080
-mjpeg 1536 864
-mjpeg 1600 900
-mjpeg 1600 1200
-mjpeg 1920 1080
-```
- 
+Please note that you have to reboot your piwebcam (power cycle it) for changes to take effect.
 
 ## Development & building
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,51 @@ The previous example sets all controls to disabled, and should thus be safe.
 The parameters directly correspond to the `bmControls` bitfields in the descriptor.
 Please, again, read the documentation linked above.
 
+### Configure available camera resolutions and streaming format
+
+The camera advertizes to the connected host PC the available resolutions and
+streaming formats of the video signal. Usually the best suitable resolution is
+chosen. The available resolutions can be reduced to enforce a specific setting.
+
+By default the camera uses the *Motion JPEG* codec to stream the video signal.
+For the host PC it offers several video resolutions up to 1080p HD video to
+choose from.
+
+These settings can be overwritten by copying the file `video_formats.txt` into
+the `/boot` folder and edit it.
+
+```bash
+cp /etc/video_formats.txt /boot
+```
+
+In this file one line corresponds to one video resolution and streaming format.
+Until now, only mjpeg and uncompressed video are supported. If you want to make
+the lower resolutions up to 720p HD unavailable, you have to comment out the
+first 4 resultions by prepending a `#` to that line.
+
+Please note that you have to reboot your piwebcam (power cyle it) for changes
+to take effect.
+
+Content of `video_formats.txt`
+```
+# Default Show-me webcam supported resolutions
+#
+# format: video format(mjpeg|uncompressed) x-dimension y-dimension
+#
+mjpeg 640 360
+mjpeg 640 480
+mjpeg 800 600
+mjpeg 1024 768
+mjpeg 1280 720
+mjpeg 1280 960
+mjpeg 1440 1080
+mjpeg 1536 864
+mjpeg 1600 900
+mjpeg 1600 1200
+mjpeg 1920 1080
+```
+ 
+
 ## Development & building
 
 Clone or download this repository. Then inside it:

--- a/package/piwebcam/piwebcam.mk
+++ b/package/piwebcam/piwebcam.mk
@@ -21,6 +21,7 @@ define PIWEBCAM_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/uvc-gadget $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
 	$(INSTALL) -D -m 0755 $(PIWEBCAM_PKGDIR)/multi-gadget.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
 	$(INSTALL) -D -m 0755 $(PIWEBCAM_PKGDIR)/start-webcam.sh $(TARGET_DIR)$(PIWEBCAM_DEST_DIR)
+	$(INSTALL) -D -m 0644 $(PIWEBCAM_PKGDIR)/video_formats.txt $(TARGET_DIR)/etc/video_formats.txt
 endef
 
 define PIWEBCAM_INSTALL_INIT_SYSTEMD

--- a/package/piwebcam/video_formats.txt
+++ b/package/piwebcam/video_formats.txt
@@ -13,4 +13,3 @@ mjpeg 1536 864
 mjpeg 1600 900
 mjpeg 1600 1200
 mjpeg 1920 1080
- 

--- a/package/piwebcam/video_formats.txt
+++ b/package/piwebcam/video_formats.txt
@@ -1,0 +1,16 @@
+# Default Show-me webcam supported resolutions
+#
+# format: video format(mjpeg|uncompressed) x-dimension y-dimension
+#
+mjpeg 640 360
+mjpeg 640 480
+mjpeg 800 600
+mjpeg 1024 768
+mjpeg 1280 720
+mjpeg 1280 960
+mjpeg 1440 1080
+mjpeg 1536 864
+mjpeg 1600 900
+mjpeg 1600 1200
+mjpeg 1920 1080
+ 


### PR DESCRIPTION
Includes the following changes:

- use [:space:] instead of \s as older versions of grep don't support \s
- remove sed as the busybox version uses different flags than gnu sed
- use awk to parse the resolutions which is less error-prone
- call config_frame before setting up streaming headers as the setup will break otherwise
- update buildroot to 2021.02.4

This replaces PR #128 