### PR TITLE
use cpu serial number instead of a fixed string

### DIFF
--- a/package/piwebcam/multi-gadget.sh
+++ b/package/piwebcam/multi-gadget.sh
@@ -32,11 +32,13 @@ echo 0x40 > bMaxPacketSize0
 mkdir -p strings/0x409
 mkdir -p configs/c.2
 mkdir -p configs/c.2/strings/0x409
-echo 100000000d2386db         > strings/0x409/serialnumber
+
+SERIAL=$(cat /sys/firmware/devicetree/base/serial-number)
+echo "$SERIAL"                > strings/0x409/serialnumber
 echo "Show-me Webcam Project" > strings/0x409/manufacturer
 echo "Piwebcam"               > strings/0x409/product
-echo 500                      > configs/c.2/MaxPower
 echo "Piwebcam"               > configs/c.2/strings/0x409/configuration
+echo 500                      > configs/c.2/MaxPower
 
 config_usb_serial () {
   mkdir -p functions/acm.usb0


### PR DESCRIPTION
Uses the internal RPi serial number instead of a fixed string.