### PR TITLE
Add sha256 checksum file to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,9 +128,13 @@ jobs:
         with:
           name: release
 
+      - name: Create checksums file
+        run: |
+          sha256sum "sdcard*" > CHECKSUMS.sha256
+
       - name: Upload Binaries to Release
         uses: alexellis/upload-assets@0.2.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["sdcard*"]'
+          asset_paths: '["sdcard*", "CHECKSUMS.sha256"]'


### PR DESCRIPTION
Closes #157 

This PR adds a step that creates a CHECKSUMS file to be uploaded with other assets on release. I do it at the end of the workflow because then we have all assets already present in the same working directory.

My first iteration was using sha512, but I decided to replace it with sha256 for no particular reason.

Please feel free to make any suggestions.