### PR TITLE
Enable only controls that the RPi camera supports

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,9 +167,15 @@ You can add the parameters to `cmdline.txt` on the boot volume as follows:
 usb_f_uvc.camera_terminal_controls=0,0,0 usb_f_uvc.processing_unit_controls=0,0
 ```
 
-The previous example sets all controls to disabled, and should thus be safe.
+The above example disables all controls and should thus be safe.
 The parameters directly correspond to the `bmControls` bitfields in the descriptor.
 Please, again, read the documentation linked above.
+
+An example for enabling all the available controls for the 8 Mpixel (v2) camera for the Raspberry Pi 4B is given below:
+
+```
+usb_f_uvc.camera_terminal_controls=10,0,0 usb_f_uvc.processing_unit_controls=219,4
+```
 
 ### Configure available camera resolutions and streaming format
 

--- a/patches/linux-custom/0001-linux-enable-more-video-controls.patch
+++ b/patches/linux-custom/0001-linux-enable-more-video-controls.patch
@@ -6,19 +6,19 @@ index fb0a892..5c850be 100644
  module_param_named(trace, uvc_gadget_trace_param, uint, 0644);
  MODULE_PARM_DESC(trace, "Trace level bitmask");
  
-+unsigned int uvc_gadget_camera_terminal_controls[3] = {2, 0, 0};
++unsigned int uvc_gadget_camera_terminal_controls[3] = {10, 0, 0};
 +module_param_array_named(camera_terminal_controls, \
 +		uvc_gadget_camera_terminal_controls, \
 +		uint, NULL, 0644);
 +MODULE_PARM_DESC(camera_terminal_controls, \
-+		"Camera terminal control availabilty bitfield");
++		"Camera terminal control availability bitfield");
 +
-+unsigned int uvc_gadget_processing_unit_controls[2] = {255, 6};
++unsigned int uvc_gadget_processing_unit_controls[2] = {219, 4};
 +module_param_array_named(processing_unit_controls, \
 +		uvc_gadget_processing_unit_controls, \
 +		uint, NULL, 0644);
 +MODULE_PARM_DESC(processing_unit_controls, \
-+		"Processing unit control availabilty bitfield");
++		"Processing unit control availability bitfield");
 +
  /* --------------------------------------------------------------------------
   * Function descriptors


### PR DESCRIPTION
The values that are currently set by default in the patch for updating the f_uvc.c kernel driver file will try to enable some controls that are not supported by the 8 Mpixel (v2) camera on the RaspberryPi 4B HW and leaves out some that are supported.

Fix the values to match exactly the controls that are possible.

I don't have any other HW than the RPi 4B + v2 camera so I don't know if these settings are completely valid on other HW combinations.

NOTE: In order to get the exposure and white balance controls working, fixes are needed also in the uvc-gadget code.
https://github.com/peterbay/uvc-gadget/pull/23