### PR TITLE
buildroot: use buildroot from official repo as submodule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     env:
-      BUILDROOT_VERSION: '2021.02.4'
+      BUILDROOT_VERSION: '170f42eb6b891e06fd500483c92a5e00f77d1dc6'
       BUILDROOT_DIR: 'buildroot'
 
     strategy:
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          submodules: 'recursive'
 
       # Retrieve annotated tags as the checkout above doesn't do this
       # https://github.com/actions/checkout/issues/217#issuecomment-636481619
@@ -57,13 +58,6 @@ jobs:
       # https://github.com/actions/virtual-environments/issues/2577
       - name: Blocked mirror workaround
         run: echo "127.0.0.1 invisible-mirror.net" | sudo tee -a /etc/hosts
-
-      - name: Download Buildroot
-        if: steps.restore-cache.outputs.cache-hit != 'true'
-        run: |
-          wget -qc https://buildroot.org/downloads/buildroot-${{ env.BUILDROOT_VERSION }}.tar.gz
-          tar -zxf buildroot-${{ env.BUILDROOT_VERSION }}.tar.gz
-          mv buildroot-${{ env.BUILDROOT_VERSION }} ${{ env.BUILDROOT_DIR }}
 
       - name: Build Image
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-buildroot
 output
 /camera.txt
 configs/*_defconfig

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "buildroot"]
+	path = buildroot
+	url = https://github.com/buildroot/buildroot.git

--- a/README.md
+++ b/README.md
@@ -205,15 +205,16 @@ Please note that you have to reboot your piwebcam (power cycle it) for changes t
 
 Clone or download this repository. Then inside it:
 
-- Download the latest Buildroot stable from https://buildroot.org/download.html
-- Extract it and rename it to `buildroot`
+- Clone the repository with submodules:
+  - `git clone --recurse-submodules https://github.com/showmewebcam/showmewebcam.git`
 - Run build command:
   - `./build-showmewebcam.sh raspberrypi0w` to build Raspberry Pi Zero W (with Wifi) image.
   - `./build-showmewebcam.sh raspberrypi0` to build Raspberry Pi Zero (without Wifi) image.
   - `./build-showmewebcam.sh raspberrypi4` to build Raspberry Pi 4 image.
-  - **IMPORTANT**: If you didn't rename your Buildroot directory to `buildroot` or if you put it somewhere else you need to set the Buildroot path manually, e.g. `BUILDROOT_DIR=../buildroot ./build-showmewebcam.sh raspberrypi0`
 - The resulting image `sdcard.img` will be in the `output/$BOARDNAME/images` folder
 - If you add a `camera.txt` file to the root of this repository, the contents will be automatically added to `/boot/camera.txt`
+
+**Note:** If you want to use external Buildroot directory you need to set the Buildroot path manually, e.g. `BUILDROOT_DIR=../buildroot ./build-showmewebcam.sh raspberrypi0`
 
 ## Credits
 


### PR DESCRIPTION
There are several pros to use this git feature:
 - no need to download from external site, less steps to start to
   build the project
 - easy to set a new version of buildroot and keep it updated
 - there is risk that the project will not be compatible with newer
   versions of buildroot, so the older version of the project
   will be rebuildable (starting with this patch)

Let's use version 2021.02.8 as it still buildable with the project.

Signed-off-by: Dmytro Kropenko <k.dmitriu@gmail.com>