### PR TITLE
improve build script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,7 @@ jobs:
           name: release
 
       - name: Create checksums file
-        run: |
-          sha256sum "sdcard*" > CHECKSUMS.sha256
+        run: sha256sum sdcard* > CHECKSUMS.sha256
 
       - name: Upload Binaries to Release
         uses: alexellis/upload-assets@0.2.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,9 +38,7 @@ jobs:
       - name: Fetch Git Tag History
         run: |
           git fetch --depth=1 origin +refs/tags/*:refs/tags/*
-          echo "SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "GIT_TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo "Current version: $(git describe)"
+          echo "SMW_VERSION=$(buildroot/support/scripts/setlocalversion)" >> $GITHUB_ENV
           echo "BUILDROOT_VERSION=$(git rev-parse --short HEAD:${BUILDROOT_DIR})" >> $GITHUB_ENV
 
       - name: Cache Build
@@ -64,26 +62,26 @@ jobs:
           # Force a piwebcam rebuild every time
           rm -fr output/*/build/piwebcam*
           sh build-showmewebcam.sh ${{ matrix.raspberry }}
-          cp output/${{ matrix.raspberry }}/images/sdcard.img sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
+          cp output/${{ matrix.raspberry }}/images/sdcard.img sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img
 
       - name: Upload Image
         uses: actions/upload-artifact@v2
         with:
-          name: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
-          path: sdcard-${{ matrix.raspberry }}-${{ env.SHA }}.img
+          name: sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img
+          path: sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img
 
       - name: Prepare Release Image
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
-          cp output/${{ matrix.raspberry }}/images/sdcard.img sdcard-${{ matrix.raspberry }}-${{ env.GIT_TAG_NAME }}.img
-          gzip sdcard-${{ matrix.raspberry }}-${{ env.GIT_TAG_NAME }}.img
+          cp output/${{ matrix.raspberry }}/images/sdcard.img sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img
+          gzip sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img
 
       - name: Store Release Image
         if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/upload-artifact@v2
         with:
           name: release
-          path: sdcard-${{ matrix.raspberry }}-${{ env.GIT_TAG_NAME }}.img.gz
+          path: sdcard-${{ matrix.raspberry }}-${{ env.SMW_VERSION }}.img.gz
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-20.04
     env:
-      BUILDROOT_VERSION: '170f42eb6b891e06fd500483c92a5e00f77d1dc6'
       BUILDROOT_DIR: 'buildroot'
 
     strategy:
@@ -42,6 +41,7 @@ jobs:
           echo "SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
           echo "GIT_TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
           echo "Current version: $(git describe)"
+          echo "BUILDROOT_VERSION=$(git rev-parse --short HEAD:${BUILDROOT_DIR})" >> $GITHUB_ENV
 
       - name: Cache Build
         id: restore-cache

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "buildroot"]
 	path = buildroot
-	url = https://github.com/buildroot/buildroot.git
+	url = https://git.buildroot.net/buildroot

--- a/board/post-build.sh
+++ b/board/post-build.sh
@@ -33,3 +33,14 @@ ln -sf /dev/null "${TARGET_DIR}"/etc/systemd/system/systemd-update-utmp-runlevel
 if [[ ${TARGET_DIR} != *"raspberrypi0cam"* ]]; then
   ln -sf /dev/null "${TARGET_DIR}"/etc/systemd/system/network.service
 fi
+
+# Set os-release file
+SHOWMEWEBCAM_VERSION=$(support/scripts/setlocalversion "${BR2_EXTERNAL_PICAM_PATH}")
+
+cat > "${TARGET_DIR}"/usr/lib/os-release <<EOF
+NAME="Show-me webcam"
+VERSION=${SHOWMEWEBCAM_VERSION}
+ID=showmewebcam
+VERSION_ID=${SHOWMEWEBCAM_VERSION}
+PRETTY_NAME="Show-me webcam ${SHOWMEWEBCAM_VERSION}"
+EOF


### PR DESCRIPTION
This PR does the following:

- Gets the buildroot commit id automatically instead of having to change release.yml every time we change it
- Properly set os-release file with the current showmewebcam version id
- Fixes the sha265sum command
- Uses the full git version description for image file names (ie. sdcard-raspberrypi0-v1.91-12-gffc2ff3.img)
- Switch to the official buildroot repository