### PR TITLE
Omit fork() before launching uvc-gadget

### DIFF
--- a/package/piwebcam/start-webcam.sh
+++ b/package/piwebcam/start-webcam.sh
@@ -22,4 +22,4 @@ else
   logger -t "$LOGGER_TAG" "No camera.txt found in boot"
 fi
 
-/opt/uvc-webcam/uvc-gadget -l -p 21 -b 3 -u /dev/video1 -v /dev/video0
+exec /opt/uvc-webcam/uvc-gadget -l -p 21 -b 3 -u /dev/video1 -v /dev/video0


### PR DESCRIPTION
Have the shell process for `start-webcam.sh` directly `exec()` the uvc-gadget, avoiding an extra shell process during the lifetime of the gadget process.

Fixes #182