### PR TITLE
package: use HTTPS link instead of GIT to download packages

### DIFF
--- a/package/camera-control/camera-control.mk
+++ b/package/camera-control/camera-control.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 CAMERA_CONTROL_VERSION = c50efb3c83be86a74fe64a72e0c2c231625138b6
-CAMERA_CONTROL_SITE = git://github.com/peterbay/camera-control.git
+CAMERA_CONTROL_SITE = https://github.com/peterbay/camera-control.git
 CAMERA_CONTROL_LICENSE = GPL-3.0+
 CAMERA_CONTROL_LICENSE_FILES = LICENSE
 CAMERA_CONTROL_DEST_DIR = /opt/camera-control

--- a/package/piwebcam/piwebcam.mk
+++ b/package/piwebcam/piwebcam.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 PIWEBCAM_VERSION = e9a733fe5c4a7fcb48e963e8d994bc33d24d814e
-PIWEBCAM_SITE = git://github.com/peterbay/uvc-gadget.git
+PIWEBCAM_SITE = https://github.com/peterbay/uvc-gadget.git
 PIWEBCAM_LICENSE = GPL-2.0+
 PIWEBCAM_LICENSE_FILES = LICENSE
 PIWEBCAM_DEST_DIR = /opt/uvc-webcam

--- a/package/soft-hwclock/soft-hwclock.mk
+++ b/package/soft-hwclock/soft-hwclock.mk
@@ -5,7 +5,7 @@
 ################################################################################
 
 SOFT_HWCLOCK_VERSION = aeaea431fb9d17005fefeeb34b80ea6fcc76adde
-SOFT_HWCLOCK_SITE = git://github.com/kristjanvalur/soft-hwclock.git
+SOFT_HWCLOCK_SITE = https://github.com/kristjanvalur/soft-hwclock.git
 SOFT_HWCLOCK_LICENSE = MIT
 SOFT_HWCLOCK_LICENSE_FILES = LICENSE
 SOFT_HWCLOCK_DEST_DIR = /opt/soft-hwclock


### PR DESCRIPTION
Unauthorized git:// links are no more supported by Github. Use https:// instead.
https://www.infoq.com/news/2021/09/github-improves-security/