### PR TITLE
buildroot: Use official GitLab repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "buildroot"]
 	path = buildroot
-	url = https://git.buildroot.net/buildroot
+	url = https://gitlab.com/buildroot.org/buildroot.git


### PR DESCRIPTION
As described in Buildroot manual:
https://buildroot.org/downloads/manual/manual.html#adding-board-support
The official repository of Buildroot is located at GitLab. Use this repository as submodule.